### PR TITLE
Series functions for timeseries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ statsmodels = "^0.11.0"
 pytest = "^5.2"
 
 # New scripts
+jupyter = "^1.0.0"
 [tool.poetry.scripts]
 scifin = 'scifin:main'
 

--- a/scifin/timeseries/timeseries.py
+++ b/scifin/timeseries/timeseries.py
@@ -202,17 +202,23 @@ class Series:
         return True
 
 
-PANDAS_METHODS = ["__add__", "__mul__"]
-for method_name in PANDAS_METHODS:
+PANDAS_METHODS = ["__add__", "__mul__", "__getitem__"]
+for name in PANDAS_METHODS:
     def create_method(method_name):
         def method(self, *args, **kwargs):
-            pd_series = self.data.iloc[:, 0]
+            pd_series = self.data
             func = getattr(pd_series, method_name)
-            new_series = func(*args, **kwargs)
-            new_df = pd.DataFrame(data=new_series, index=new_series.index)
-            return Series(new_df, tz=self.tz, unit=self.unit, name=self.name)
+            new_args = []
+            for arg in args:
+                # if one of the args is a series turn into a pd.Series
+                if isinstance(arg, Series):
+                    new_args.append(arg.data)
+                else:
+                    new_args.append(arg)
+            new_series = func(*new_args, **kwargs)
+            return Series(new_series, tz=self.tz, unit=self.unit, name=self.name)
         return method
-    setattr(Series, method_name, create_method(method_name))
+    setattr(Series, name, create_method(name))
 
 
 #---------#---------#---------#---------#---------#---------#---------#---------#---------#

--- a/scifin/timeseries/timeseries.py
+++ b/scifin/timeseries/timeseries.py
@@ -200,9 +200,19 @@ class Series:
             if intervals[i] - prev > 1.e-6:
                 return False
         return True
-    
 
-    
+
+PANDAS_METHODS = ["__add__", "__mul__"]
+for method_name in PANDAS_METHODS:
+    def create_method(method_name):
+        def method(self, *args, **kwargs):
+            pd_series = self.data.iloc[:, 0]
+            func = getattr(pd_series, method_name)
+            new_series = func(*args, **kwargs)
+            new_df = pd.DataFrame(data=new_series, index=new_series.index)
+            return Series(new_df, tz=self.tz, unit=self.unit, name=self.name)
+        return method
+    setattr(Series, method_name, create_method(method_name))
 
 
 #---------#---------#---------#---------#---------#---------#---------#---------#---------#

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -159,13 +159,13 @@ class TestTimeSeries(unittest.TestCase):
         test_df.loc['2020-01'] = 1.
         test_df.loc['2020-02'] = 2.
         test_df.loc['2020-03'] = 3.
-        ts1 = ts.TimeSeries(df=test_df, tz="Europe/London", unit='£', name="Test a time series")
+        ts1 = ts.TimeSeries(data=test_df, tz="Europe/London", unit='£', name="Test a time series")
 
         expected = [4., 5., 6.]
 
         # When
         sum_result = ts1 + 3
-        actual = list(sum_result.data.iloc[:, 0])
+        actual = list(sum_result.data)
 
         # Then
         self.assertListEqual(expected, actual)
@@ -176,13 +176,33 @@ class TestTimeSeries(unittest.TestCase):
         test_df.loc['2020-01'] = 1.
         test_df.loc['2020-02'] = 2.
         test_df.loc['2020-03'] = 3.
-        ts1 = ts.TimeSeries(df=test_df, tz="Europe/London", unit='£', name="Test a time series")
+        ts1 = ts.TimeSeries(data=test_df, tz="Europe/London", unit='£', name="Test a time series")
 
         expected = [4., 6., 8.]
 
         # When
         sum_result = ts1 + [3, 4, 5]
-        actual = list(sum_result.data.iloc[:, 0])
+        actual = list(sum_result.data)
+
+        # Then
+        self.assertListEqual(expected, actual)
+
+    def test_add_ts(self):
+        # Given
+        test_df = pd.DataFrame(columns=['ts'], index=['2020-01', '2020-02', '2020-03'])
+        test_df.loc['2020-01'] = 1.
+        test_df.loc['2020-02'] = 2.
+        test_df.loc['2020-03'] = 3.
+        ts1 = ts.TimeSeries(data=test_df, tz="Europe/London", unit='£', name="Test a time series")
+
+        # create a ts with all ones
+        ts2 = ts1 * 0 + 1
+
+        expected = [2., 3., 4.]
+
+        # When
+        sum_result = ts1 + ts2
+        actual = list(sum_result.data)
 
         # Then
         self.assertListEqual(expected, actual)
@@ -193,19 +213,41 @@ class TestTimeSeries(unittest.TestCase):
         test_df.loc['2020-01'] = 1.
         test_df.loc['2020-02'] = 2.
         test_df.loc['2020-03'] = 3.
-        ts1 = ts.TimeSeries(df=test_df, tz="Europe/London", unit='£', name="Test a time series")
+        ts1 = ts.TimeSeries(data=test_df, tz="Europe/London", unit='£', name="Test a time series")
 
         expected = [10., 20., 30.]
 
         # When
         mul_result = ts1 * 10
-        actual = list(mul_result.data.iloc[:, 0])
+        actual = list(mul_result.data)
 
         # Then
         self.assertListEqual(expected, actual)
 
-        
-        
+    def test_slicing(self):
+        # Given
+        series = pd.Series([0, 1, 2, 3, 4, 5, 6])
+        ts1 = ts.TimeSeries(data=series, tz="Europe/London", unit='£', name="Test a time series")
+
+        # slicing with start and end
+        expected = pd.Series([1, 2], index=[1, 2])
+        actual = ts1[1:3].data
+        self.assertListEqual(list(expected.values), list(actual.values))
+        self.assertListEqual(list(expected.index), list(actual.index))
+
+        # slicing with start and without end
+        expected = pd.Series([5, 6], index=[5, 6])
+        actual = ts1[5:].data
+        self.assertListEqual(list(expected.values), list(actual.values))
+        self.assertListEqual(list(expected.index), list(actual.index))
+
+        # slicing with step
+        expected = pd.Series([0, 2, 4, 6], index=[0, 2, 4, 6])
+        actual = ts1[::2].data
+        self.assertListEqual(list(expected.values), list(actual.values))
+        self.assertListEqual(list(expected.index), list(actual.index))
+
+
 if __name__ == '__main__':
     unittest.main()
     

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -152,6 +152,58 @@ class TestTimeSeries(unittest.TestCase):
         self.assertEqual(self.cts1.timezone, pytz.timezone("UTC"))
         self.assertEqual(self.cts1.name, "Test a categorical time series")
         self.assertEqual(self.cts1.type, 'CatTimeSeries')
+
+    def test_add_constant(self):
+        # Given
+        test_df = pd.DataFrame(columns=['ts'], index=['2020-01', '2020-02', '2020-03'])
+        test_df.loc['2020-01'] = 1.
+        test_df.loc['2020-02'] = 2.
+        test_df.loc['2020-03'] = 3.
+        ts1 = ts.TimeSeries(df=test_df, tz="Europe/London", unit='£', name="Test a time series")
+
+        expected = [4., 5., 6.]
+
+        # When
+        sum_result = ts1 + 3
+        actual = list(sum_result.data.iloc[:, 0])
+
+        # Then
+        self.assertListEqual(expected, actual)
+
+    def test_add_list(self):
+        # Given
+        test_df = pd.DataFrame(columns=['ts'], index=['2020-01', '2020-02', '2020-03'])
+        test_df.loc['2020-01'] = 1.
+        test_df.loc['2020-02'] = 2.
+        test_df.loc['2020-03'] = 3.
+        ts1 = ts.TimeSeries(df=test_df, tz="Europe/London", unit='£', name="Test a time series")
+
+        expected = [4., 6., 8.]
+
+        # When
+        sum_result = ts1 + [3, 4, 5]
+        actual = list(sum_result.data.iloc[:, 0])
+
+        # Then
+        self.assertListEqual(expected, actual)
+
+    def test_multiply_by_constant(self):
+        # Given
+        test_df = pd.DataFrame(columns=['ts'], index=['2020-01', '2020-02', '2020-03'])
+        test_df.loc['2020-01'] = 1.
+        test_df.loc['2020-02'] = 2.
+        test_df.loc['2020-03'] = 3.
+        ts1 = ts.TimeSeries(df=test_df, tz="Europe/London", unit='£', name="Test a time series")
+
+        expected = [10., 20., 30.]
+
+        # When
+        mul_result = ts1 * 10
+        actual = list(mul_result.data.iloc[:, 0])
+
+        # Then
+        self.assertListEqual(expected, actual)
+
         
         
 if __name__ == '__main__':


### PR DESCRIPTION
This patch adds a generic way to port pd.Series functionalities to our Series class.
For the moment I added ``__add__``,`` __mul__`` and ``__getitem__`` along with the corresponding tests.